### PR TITLE
feat: specify the grpc connpool size in kitex-grpc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/apache/thrift v0.14.0
 	github.com/cloudfoundry/gosigar v1.3.3
-	github.com/cloudwego/kitex v0.1.3
+	github.com/cloudwego/kitex v0.2.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/lesismal/arpc v1.2.4
 	github.com/lesismal/nbio v1.1.23-0.20210815145206-b106d99bce56

--- a/go.sum
+++ b/go.sum
@@ -54,11 +54,11 @@ github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudfoundry/gosigar v1.3.3 h1:aR9qIZ/Njb4GYPUGnoJMfXdhz+AOy80r4r3LUQC5A0g=
 github.com/cloudfoundry/gosigar v1.3.3/go.mod h1:4TGthjsfIxe6Svlzn48EUw9xTTjT/2NnWyeRrferFP0=
-github.com/cloudwego/kitex v0.1.3 h1:fWVZR4TuKbLTK6JxWbHhmUyOAqyEmhW+CqnOrx674nU=
-github.com/cloudwego/kitex v0.1.3/go.mod h1:qxxpIUl5zvbcvcQeKrlm2t2f1BBxt4EPMksBUFwr6QA=
+github.com/cloudwego/kitex v0.2.0 h1:Vrtns1/giZGLCyX8CjTcYQ2RHG4wnmSLnLpuLu/BfPc=
+github.com/cloudwego/kitex v0.2.0/go.mod h1:1p4rtGIIiFZMOePYbSPgLkIhdhdfhEtVOJSti/k9vK4=
 github.com/cloudwego/netpoll v0.1.0/go.mod h1:rZOiNI0FYjuvNybXKKhAPUja03loJi/cdv2F55AE6E8=
-github.com/cloudwego/netpoll v0.1.2 h1:NSvqHfCmmR3g0ASshwAB0F2RJvXK8v7ToFmhWzh/ukY=
-github.com/cloudwego/netpoll v0.1.2/go.mod h1:rZOiNI0FYjuvNybXKKhAPUja03loJi/cdv2F55AE6E8=
+github.com/cloudwego/netpoll v0.2.0 h1:MmZX/jS6ozso86mnbVJ7fUO1hL4LOH/XngXN7Pn347A=
+github.com/cloudwego/netpoll v0.2.0/go.mod h1:rZOiNI0FYjuvNybXKKhAPUja03loJi/cdv2F55AE6E8=
 github.com/cloudwego/netpoll-http2 v0.0.6 h1:+jdkMKGj7ifRqWOdyT/hqzhXklmqh/H4lyOdrAVkI/U=
 github.com/cloudwego/netpoll-http2 v0.0.6/go.mod h1:+bjPyu2Cd4GDzKa0IegPgp1hjMjpZ6/kXTsSjIsmUk8=
 github.com/cloudwego/thriftgo v0.1.2 h1:AXpGJiWE3VggfiRHwA6raRJUIcjxliEIfJfGlvRiYUA=

--- a/grpc/kitex/client/kitex_client.go
+++ b/grpc/kitex/client/kitex_client.go
@@ -34,6 +34,7 @@ func NewKClient(opt *runner.Options) runner.Client {
 		client: echosvr.MustNewClient("test.echo.kitex",
 			client.WithHostPorts(opt.Address),
 			client.WithTransportProtocol(transport.GRPC),
+			client.WithGRPCConnPoolSize(6), // the cpu cores of server is 4, and 4*3/2 = 6
 		),
 		reqPool: &sync.Pool{
 			New: func() interface{} {


### PR DESCRIPTION
在 kitex-gRPC 中指定连接池大小为6，因为 sever 核数为4，按照计算公式 4*3/2 = 6，这样 server 可以获得最佳性能