### PR TITLE
fix: output dir drop /bin

### DIFF
--- a/scripts/build_grpc.sh
+++ b/scripts/build_grpc.sh
@@ -3,6 +3,10 @@ set -e
 GOEXEC=${GOEXEC:-"go"}
 
 # clean
+if [ -z "$output_dir" ]; then
+  echo "output_dir is empty"
+  exit 1
+fi
 rm -rf $output_dir/bin/ && mkdir -p $output_dir/bin/
 rm -rf $output_dir/log/ && mkdir -p $output_dir/log/
 

--- a/scripts/build_pb.sh
+++ b/scripts/build_pb.sh
@@ -3,6 +3,10 @@ set -e
 GOEXEC=${GOEXEC:-"go"}
 
 # clean
+if [ -z "$output_dir" ]; then
+  echo "output_dir is empty"
+  exit 1
+fi
 rm -rf $output_dir/bin/ && mkdir -p $output_dir/bin/
 rm -rf $output_dir/log/ && mkdir -p $output_dir/log/
 

--- a/scripts/build_thrift.sh
+++ b/scripts/build_thrift.sh
@@ -4,6 +4,10 @@ CURDIR=$(cd $(dirname $0); pwd)
 GOEXEC=${GOEXEC:-"go"}
 
 # clean
+if [ -z "$output_dir" ]; then
+  echo "output_dir is empty"
+  exit 1
+fi
 rm -rf $output_dir/bin/ && mkdir -p $output_dir/bin/
 rm -rf $output_dir/log/ && mkdir -p $output_dir/log/
 


### PR DESCRIPTION
#### What type of PR is this?
fix

#### What this PR does / why we need it (en: English/zh: Chinese):
en:  add output_dir check to prevent accidental deletion of /bin directory
zh: 添加output_dir校验防止误删/bin目录

#### Which issue(s) this PR fixes:
